### PR TITLE
fix error: ‘int maj’ redeclared as different kind of entity

### DIFF
--- a/A51.c
+++ b/A51.c
@@ -74,7 +74,7 @@ int main(){
         }
 }
 
-int maj(x ,y, z){
+int maj(int x, int y, int z){
         int m;
         if(x == 0){
                 if(y == 0 || z == 0){


### PR DESCRIPTION
I tried compiling the code in Ubuntu 20.04 with g++ (Ubuntu 9.4.0-1ubuntu1~20.04.1) 9.4.0 and got this error. Just a minor fix in declaring the parameters for function int maj(). I hope that you could review this pull request of mine. Many thanks!